### PR TITLE
second commit

### DIFF
--- a/assets/hepdata/ppg228/RdAu_RpAu_020_pT.yaml
+++ b/assets/hepdata/ppg228/RdAu_RpAu_020_pT.yaml
@@ -105,82 +105,82 @@ dependent_variables:
   qualifiers:
   - {name: '', value: '$R_{pAu}$ 0-20% Centrality $(-2.2 < y < -1.2)$'}
   values:
-  - value: 0.67
+  - value: 0.61
     errors:
-    - {symerror: 0.10, label: 'stat'}
+    - {symerror: 0.09, label: 'stat'}
     - {symerror: 0.05, label: 'sys'}
-  - value: 0.75
+  - value: 0.72
     errors:
     - {symerror: 0.06, label: 'stat'}
     - {symerror: 0.06, label: 'sys'}
-  - value: 0.66
+  - value: 0.65
     errors:
-    - {symerror: 0.06, label: 'stat'}
+    - {symerror: 0.05, label: 'stat'}
     - {symerror: 0.05, label: 'sys'}
-  - value: 0.78
+  - value: 0.71
     errors:
     - {symerror: 0.05, label: 'stat'}
     - {symerror: 0.06, label: 'sys'}
-  - value: 0.92
+  - value: 0.85
     errors:
-    - {symerror: 0.06, label: 'stat'}
+    - {symerror: 0.04, label: 'stat'}
     - {symerror: 0.07, label: 'sys'}
-  - value: 0.79
+  - value: 0.74
     errors:
-    - {symerror: 0.06, label: 'stat'}
+    - {symerror: 0.05, label: 'stat'}
     - {symerror: 0.06, label: 'sys'}
   - value: 0.91
     errors:
-    - {symerror: 0.07, label: 'stat'}
+    - {symerror: 0.06, label: 'stat'}
     - {symerror: 0.07, label: 'sys'}
-  - value: 0.81
+  - value: 0.92
     errors:
-    - {symerror: 0.08, label: 'stat'}
-    - {symerror: 0.06, label: 'sys'}
-  - value: 0.96
-    errors:
-    - {symerror: 0.09, label: 'stat'}
+    - {symerror: 0.06, label: 'stat'}
     - {symerror: 0.08, label: 'sys'}
-  - value: 0.86
-    errors:
-    - {symerror: 0.09, label: 'stat'}
-    - {symerror: 0.07, label: 'sys'}
   - value: 1.07
     errors:
-    - {symerror: 0.13, label: 'stat'}
+    - {symerror: 0.09, label: 'stat'}
     - {symerror: 0.09, label: 'sys'}
-  - value: 1.03
+  - value: 1.02
     errors:
-    - {symerror: 0.13, label: 'stat'}
+    - {symerror: 0.08, label: 'stat'}
     - {symerror: 0.09, label: 'sys'}
-  - value: 1.14
+  - value: 1.19
+    errors:
+    - {symerror: 0.10, label: 'stat'}
+    - {symerror: 0.10, label: 'sys'}
+  - value: 0.95
+    errors:
+    - {symerror: 0.10, label: 'stat'}
+    - {symerror: 0.08, label: 'sys'}
+  - value: 1.07
+    errors:
+    - {symerror: 0.12, label: 'stat'}
+    - {symerror: 0.09, label: 'sys'}
+  - value: 1.13
     errors:
     - {symerror: 0.14, label: 'stat'}
     - {symerror: 0.10, label: 'sys'}
-  - value: 1.43
+  - value: 1.27
     errors:
-    - {symerror: 0.17, label: 'stat'}
-    - {symerror: 0.12, label: 'sys'}
+    - {symerror: 0.16, label: 'stat'}
+    - {symerror: 0.11, label: 'sys'}
   - value: 1.08
     errors:
-    - {symerror: 0.18, label: 'stat'}
-    - {symerror: 0.09, label: 'sys'}
-  - value: 0.98
+    - {symerror: 0.17, label: 'stat'}
+    - {symerror: 0.10, label: 'sys'}
+  - value: 1.35
     errors:
-    - {symerror: 0.19, label: 'stat'}
+    - {symerror: 0.16, label: 'stat'}
+    - {symerror: 0.12, label: 'sys'}
+  - value: 1.46
+    errors:
+    - {symerror: 0.24, label: 'stat'}
+    - {symerror: 0.13, label: 'sys'}
+  - value: 0.85
+    errors:
+    - {symerror: 0.12, label: 'stat'}
     - {symerror: 0.08, label: 'sys'}
-  - value: 1.79
-    errors:
-    - {symerror: 0.22, label: 'stat'}
-    - {symerror: 0.15, label: 'sys'}
-  - value: 1.60
-    errors:
-    - {symerror: 0.31, label: 'stat'}
-    - {symerror: 0.14, label: 'sys'}
-  - value: 1.01
-    errors:
-    - {symerror: 0.15, label: 'stat'}
-    - {symerror: 0.09, label: 'sys'}
 - header: {name: '$Ratio$'}
   qualifiers:
   - {name: '', value: '$R_{dAu}/R_{pAu}$ 0-20% Centrality $(1.2 < y < 2.2)$'}

--- a/assets/hepdata/ppg228/RpAl_TA.yaml
+++ b/assets/hepdata/ppg228/RpAl_TA.yaml
@@ -1,45 +1,45 @@
 independent_variables:
 - header: {name: '$\langle T_{A} \rangle [fm^{-2}]$'}
   values:
-  - {value: 1.21}
-  - {value: 1.57}
-  - {value: 1.78}
+  - {value: 0.55}
+  - {value: 0.62}
+  - {value: 0.68}
 dependent_variables:
 - header: {name: '$\frac{dN^{AB}/dy}{\langle N_{coll} \rangle dN^{pp}/dy}$  (global sys. err. 10.1%)'}
   qualifiers:
   - {name: '', value: '$R_{pAl}$,  p+Al$\sqrt{s_{NN}}$=200GeV, $1.2 < y < 2.2$'}
   values:
-  - value: 0.97
+  - value: 1.24
     errors:
-    - {symerror: 0.06, label: 'stat'}
+    - {symerror: 0.04, label: 'stat'}
     - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.08, label: 'y sys'}
-  - value: 0.85
-    errors:
-    - {symerror: 0.05, label: 'stat'}
-    - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.07, label: 'y sys'}
-  - value: 0.68
-    errors:
-    - {symerror: 0.03, label: 'stat'}
-    - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.06, label: 'y sys'}
-- header: {name: '$\frac{dN^{AB}/dy}{\langle N_{coll} \rangle dN^{pp}/dy}$  (global sys. err. 10.1%)'}
-  qualifiers:
-  - {name: '', value: '$R_{pAl}$,  p+Al$\sqrt{s_{NN}}$=200GeV, $-2.2 < y < -1.2$'}
-  values:
-  - value: 1.01
+    - {symerror: 0.11, label: 'y sys'}
+  - value: 1.15
     errors:
     - {symerror: 0.05, label: 'stat'}
     - {symerror: 0.35, label: 'x sys'}
     - {symerror: 0.10, label: 'y sys'}
-  - value: 0.81
+  - value: 0.86
+    errors:
+    - {symerror: 0.03, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.08, label: 'y sys'}
+- header: {name: '$\frac{dN^{AB}/dy}{\langle N_{coll} \rangle dN^{pp}/dy}$  (global sys. err. 10.1%)'}
+  qualifiers:
+  - {name: '', value: '$R_{pAl}$,  p+Al$\sqrt{s_{NN}}$=200GeV, $-2.2 < y < -1.2$'}
+  values:
+  - value: 1.18
     errors:
     - {symerror: 0.05, label: 'stat'}
     - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.08, label: 'y sys'}
-  - value: 0.76
+    - {symerror: 0.11, label: 'y sys'}
+  - value: 1.24
     errors:
-    - {symerror: 0.04, label: 'stat'}
+    - {symerror: 0.05, label: 'stat'}
     - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.07, label: 'y sys'}
+    - {symerror: 0.11, label: 'y sys'}
+  - value: 1.07
+    errors:
+    - {symerror: 0.05, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.10, label: 'y sys'}

--- a/assets/hepdata/ppg228/RpAl_ncoll.yaml
+++ b/assets/hepdata/ppg228/RpAl_ncoll.yaml
@@ -9,21 +9,21 @@ dependent_variables:
   qualifiers:
   - {name: '', value: '$R_{pAl}$,  p+Al$\sqrt{s_{NN}}$=200GeV, $1.2 < y < 2.2$'}
   values:
-  - value: 1.18
-    errors:
-    - {symerror: 0.05, label: 'stat'}
-    - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.11, label: 'y sys'}
   - value: 1.24
     errors:
-    - {symerror: 0.05, label: 'stat'}
+    - {symerror: 0.03, label: 'stat'}
     - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.12, label: 'y sys'}
-  - value: 1.07
+    - {symerror: 0.11, label: 'y sys'}
+  - value: 1.15
     errors:
     - {symerror: 0.05, label: 'stat'}
     - {symerror: 0.35, label: 'x sys'}
     - {symerror: 0.10, label: 'y sys'}
+  - value: 0.86
+    errors:
+    - {symerror: 0.04, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.08, label: 'y sys'}
 - header: {name: '$\frac{dN^{AB}/dy}{\langle N_{coll} \rangle dN^{pp}/dy}$  (global err. 10.1%)'}
   qualifiers:
   - {name: '', value: '$R_{pAl}$,  p+Al$\sqrt{s_{NN}}$=200GeV, $-2.2 < y < -1.2$'}

--- a/assets/hepdata/ppg228/RpAu_TA.yaml
+++ b/assets/hepdata/ppg228/RpAu_TA.yaml
@@ -1,45 +1,78 @@
 independent_variables:
 - header: {name: '$\langle T_{A} \rangle [fm^{-2}]$'}
   values:
-  - {value: 1.21}
-  - {value: 1.57}
-  - {value: 1.78}
+  - {value: 2.6}
+  - {value: 4.4}
+  - {value: 6.1}
+  - {value: 7.4}
+  - {value: 8.4}
+  - {value: 9.7}
 dependent_variables:
 - header: {name: '$\frac{dN^{AB}/dy}{\langle N_{coll} \rangle dN^{pp}/dy}$  (global sys. err. 10.1%)'}
   qualifiers:
-  - {name: '', value: '$R_{pAu}$,  p+Au$\sqrt{s_{NN}}$=200GeV, $1.2 < y < 2.2$'}
+  - {name: '$\langle T_{A} \rangle [fm^{-2}]$', value: '$R_{^3HeAu}$,  p+Al$\sqrt{s_{NN}}$=200GeV, $1.2 < y < 2.2$'}
   values:
-  - value: 0.97
+  - value: 1.16
     errors:
-    - {symerror: 0.06, label: 'stat'}
+    - {symerror: 0.04, label: 'stat'}
     - {symerror: 0.35, label: 'x sys'}
     - {symerror: 0.08, label: 'y sys'}
-  - value: 0.85
-    errors:
-    - {symerror: 0.05, label: 'stat'}
-    - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.07, label: 'y sys'}
-  - value: 0.68
-    errors:
-    - {symerror: 0.03, label: 'stat'}
-    - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.06, label: 'y sys'}
-- header: {name: '$\frac{dN^{AB}/dy}{\langle N_{coll} \rangle dN^{pp}/dy}$  (global sys. err. 10.1%)'}
-  qualifiers:
-  - {name: '', value: '$R_{pAu}$,  p+Au$\sqrt{s_{NN}}$=200GeV, $-2.2 < y < -1.2$'}
-  values:
-  - value: 1.01
-    errors:
-    - {symerror: 0.05, label: 'stat'}
-    - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.10, label: 'y sys'}
-  - value: 0.81
-    errors:
-    - {symerror: 0.05, label: 'stat'}
-    - {symerror: 0.35, label: 'x sys'}
-    - {symerror: 0.08, label: 'y sys'}
-  - value: 0.76
+  - value: 1.47
     errors:
     - {symerror: 0.04, label: 'stat'}
     - {symerror: 0.35, label: 'x sys'}
     - {symerror: 0.07, label: 'y sys'}
+  - value: 1.61
+    errors:
+    - {symerror: 0.03, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.07, label: 'y sys'}
+  - value: 1.70
+    errors:
+    - {symerror: 0.03, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.06, label: 'y sys'}
+  - value: 1.78
+    errors:
+    - {symerror: 0.03, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.05, label: 'y sys'}
+  - value: 1.83
+    errors:
+    - {symerror: 0.02, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.04, label: 'y sys'}
+- header: {name: '$\frac{dN^{AB}/dy}{\langle N_{coll} \rangle dN^{pp}/dy}$  (global sys. err. 10.1%)'}
+  qualifiers:
+  - {name: '$\langle T_{A} \rangle [fm^{-2}]$', value: '$R_{^3HeAu}$,  p+Al$\sqrt{s_{NN}}$=200GeV, $-2.2 < y < -1.2$'}
+  values:
+  - value: 1.16
+    errors:
+    - {symerror: 0.04, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.08, label: 'y sys'}
+  - value: 1.47
+    errors:
+    - {symerror: 0.05, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.09, label: 'y sys'}
+  - value: 1.61
+    errors:
+    - {symerror: 0.04, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.09, label: 'y sys'}
+  - value: 1.70
+    errors:
+    - {symerror: 0.04, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.09, label: 'y sys'}
+  - value: 1.78
+    errors:
+    - {symerror: 0.04, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.09, label: 'y sys'}
+  - value: 1.83
+    errors:
+    - {symerror: 0.04, label: 'stat'}
+    - {symerror: 0.35, label: 'x sys'}
+    - {symerror: 0.09, label: 'y sys'}

--- a/assets/hepdata/ppg228/inv_MB_y.yaml
+++ b/assets/hepdata/ppg228/inv_MB_y.yaml
@@ -86,6 +86,42 @@ dependent_variables:
   qualifiers:
   - {name: '', value: '$B_{ll} \frac{dN}{dy}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 0-100% Centrality, $1.2 < |y| < 2.2$'}
   values:
+  - value: 1.26e-6
+    errors:
+    - {symerror: 5.50e-8, label: 'stat'}
+    - {symerror: 1.52e-7, label: 'sys'}
+  - value: 2.17e-6
+    errors:
+    - {symerror: 4.35e-8, label: 'stat'}
+    - {symerror: 2.92e-7, label: 'sys'}
+  - value: 2.97e-6
+    errors:
+    - {symerror: 5.85e-8, label: 'stat'}
+    - {symerror: 4.33e-7, label: 'sys'}
+  - value: 3.84e-6
+    errors:
+    - {symerror: 1.27e-7, label: 'stat'}
+    - {symerror: 5.91e-7, label: 'sys'}
+  - value: 3.16e-6
+    errors:
+    - {symerror: 9.75e-8, label: 'stat'}
+    - {symerror: 4.43e-7, label: 'sys'}
+  - value: 2.63e-6
+    errors:
+    - {symerror: 3.97e-8, label: 'stat'}
+    - {symerror: 3.77e-7, label: 'sys'}
+  - value: 1.73e-6
+    errors:
+    - {symerror: 2.91e-8, label: 'stat'}
+    - {symerror: 2.20e-7, label: 'sys'}
+  - value: 1.27e-6
+    errors:
+    - {symerror: 2.86e-8, label: 'stat'}
+    - {symerror: 1.47e-7, label: 'sys'}
+- header: {name: '$\frac{1}{ \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
+  qualifiers:
+  - {name: '', value: '$B_{ll} \frac{dN}{dy}$,  $^{3}$He+Au$\sqrt{s_{NN}}$=200GeV, 0-100% Centrality, $1.2 < |y| < 2.2$'}
+  values:
   - value: 3.72e-6
     errors:
     - {symerror: 3.20e-7, label: 'stat'}
@@ -118,39 +154,3 @@ dependent_variables:
     errors:
     - {symerror: 1.42e-7, label: 'stat'}
     - {symerror: 3.07e-7, label: 'sys'}
-- header: {name: '$\frac{1}{ \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
-  qualifiers:
-  - {name: '', value: '$B_{ll} \frac{dN}{dy}$,  $^{3}$He+Au$\sqrt{s_{NN}}$=200GeV, 0-100% Centrality, $1.2 < |y| < 2.2$'}
-  values:
-  - value: 6.93e-6
-    errors:
-    - {symerror: 7.42e-7, label: 'stat'}
-    - {symerror: 3.66e-8, label: 'sys'}
-  - value: 9.67e-6
-    errors:
-    - {symerror: 6.32e-7, label: 'stat'}
-    - {symerror: 5.71e-8, label: 'sys'}
-  - value: 1.15e-5
-    errors:
-    - {symerror: 5.99e-7, label: 'stat'}
-    - {symerror: 7.42e-8, label: 'sys'}
-  - value: 1.51e-5
-    errors:
-    - {symerror: 1.41e-6, label: 'stat'}
-    - {symerror: 1.04e-7, label: 'sys'}
-  - value: 1.28e-5
-    errors:
-    - {symerror: 1.46e-6, label: 'stat'}
-    - {symerror: 7.90e-8, label: 'sys'}
-  - value: 1.10e-5
-    errors:
-    - {symerror: 5.72e-7, label: 'stat'}
-    - {symerror: 6.99e-8, label: 'sys'}
-  - value: 8.13e-6
-    errors:
-    - {symerror: 4.94e-7, label: 'stat'}
-    - {symerror: 4.60e-8, label: 'sys'}
-  - value: 6.13e-6
-    errors:
-    - {symerror: 5.68e-7, label: 'stat'}
-    - {symerror: 3.17e-8, label: 'sys'}

--- a/assets/hepdata/ppg228/pAu_inv_cent_pT_N.yaml
+++ b/assets/hepdata/ppg228/pAu_inv_cent_pT_N.yaml
@@ -23,561 +23,557 @@ independent_variables:
 dependent_variables:
 - header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
   qualifiers:
-  - {name: '', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 0-5% Centrality, $1.2 < y < 2.2$'}
+  - {name: '$p_{T}[GeV/c]$', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 0--5% Centrality, $1.2 < y < 2.2$'}
   values:
-  - value: 5.17e-7
-    errors:
-    - {symerror: 1.17e-71.11e-7, label: 'stat'}
-    - {symerror: 1.17e-71.11e-7, label: 'sys'}
-  - value: 4.65e-7
-    errors:
-    - {symerror: 7.94e-89.94e-8, label: 'stat'}
-    - {symerror: 7.94e-89.94e-8, label: 'sys'}
-  - value: 4.10e-7
-    errors:
-    - {symerror: 5.55e-88.66e-8, label: 'stat'}
-    - {symerror: 5.55e-88.66e-8, label: 'sys'}
-  - value: 3.54e-7
-    errors:
-    - {symerror: 4.30e-87.38e-8, label: 'stat'}
-    - {symerror: 4.30e-87.38e-8, label: 'sys'}
-  - value: 3.58e-7
-    errors:
-    - {symerror: 3.80e-87.32e-8, label: 'stat'}
-    - {symerror: 3.80e-87.32e-8, label: 'sys'}
-  - value: 2.54e-7
-    errors:
-    - {symerror: 2.65e-85.07e-8, label: 'stat'}
-    - {symerror: 2.65e-85.07e-8, label: 'sys'}
-  - value: 2.29e-7
-    errors:
-    - {symerror: 2.27e-84.48e-8, label: 'stat'}
-    - {symerror: 2.27e-84.48e-8, label: 'sys'}
-  - value: 1.81e-7
-    errors:
-    - {symerror: 1.72e-83.45e-8, label: 'stat'}
-    - {symerror: 1.72e-83.45e-8, label: 'sys'}
-  - value: 1.29e-7
-    errors:
-    - {symerror: 1.52e-82.41e-8, label: 'stat'}
-    - {symerror: 1.52e-82.41e-8, label: 'sys'}
-  - value: 9.81e-8
-    errors:
-    - {symerror: 1.06e-81.81e-8, label: 'stat'}
-    - {symerror: 1.06e-81.81e-8, label: 'sys'}
-  - value: 7.29e-8
-    errors:
-    - {symerror: 9.43e-91.32e-8, label: 'stat'}
-    - {symerror: 9.43e-91.32e-8, label: 'sys'}
-  - value: 3.99e-8
-    errors:
-    - {symerror: 6.90e-97.17e-9, label: 'stat'}
-    - {symerror: 6.90e-97.17e-9, label: 'sys'}
-  - value: 3.85e-8
-    errors:
-    - {symerror: 5.50e-96.85e-9, label: 'stat'}
-    - {symerror: 5.50e-96.85e-9, label: 'sys'}
-  - value: 2.83e-8
-    errors:
-    - {symerror: 4.93e-94.98e-9, label: 'stat'}
-    - {symerror: 4.93e-94.98e-9, label: 'sys'}
-  - value: 1.77e-8
-    errors:
-    - {symerror: 4.42e-93.06e-9, label: 'stat'}
-    - {symerror: 4.42e-93.06e-9, label: 'sys'}
-  - value: 1.09e-8
-    errors:
-    - {symerror: 2.48e-91.86e-9, label: 'stat'}
-    - {symerror: 2.48e-91.86e-9, label: 'sys'}
-  - value: 8.92e-9
-    errors:
-    - {symerror: 1.45e-91.48e-9, label: 'stat'}
-    - {symerror: 1.45e-91.48e-9, label: 'sys'}
-  - value: 3.18e-9
-    errors:
-    - {symerror: 8.38e-10, label: 'stat'}
-    - {symerror: 5.18e-10, label: 'sys'}
-  - value: 2.62e-10
-    errors:
-    - {symerror: 8.73e-11, label: 'stat'}
-    - {symerror: 4.17e-11, label: 'sys'}
-- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
-  qualifiers:
-  - {name: '', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 5-10% Centrality, $1.2 < y < 2.2$'}
-  values:
-  - value: 4.23e-7
-    errors:
-    - {symerror: 9.20e-8, label: 'stat'}
-    - {symerror: 9.13e-8, label: 'sys'}
-  - value: 4.61e-7
-    errors:
-    - {symerror: 6.50e-8, label: 'stat'}
-    - {symerror: 9.86e-8, label: 'sys'}
-  - value: 3.79e-7
-    errors:
-    - {symerror: 4.56e-8, label: 'stat'}
-    - {symerror: 8.01e-8, label: 'sys'}
-  - value: 3.25e-7
-    errors:
-    - {symerror: 5.03e-8, label: 'stat'}
-    - {symerror: 6.77e-8, label: 'sys'}
-  - value: 3.40e-7
-    errors:
-    - {symerror: 2.98e-8, label: 'stat'}
-    - {symerror: 6.94e-8, label: 'sys'}
-  - value: 2.60e-7
-    errors:
-    - {symerror: 2.32e-8, label: 'stat'}
-    - {symerror: 5.19e-8, label: 'sys'}
-  - value: 1.87e-7
-    errors:
-    - {symerror: 1.85e-8, label: 'stat'}
-    - {symerror: 3.64e-8, label: 'sys'}
-  - value: 1.59e-7
-    errors:
-    - {symerror: 1.63e-8, label: 'stat'}
-    - {symerror: 3.03e-8, label: 'sys'}
-  - value: 9.67e-8
-    errors:
-    - {symerror: 1.45e-8, label: 'stat'}
-    - {symerror: 1.81e-8, label: 'sys'}
-  - value: 7.35e-8
-    errors:
-    - {symerror: 1.09e-8, label: 'stat'}
-    - {symerror: 1.35e-8, label: 'sys'}
-  - value: 5.87e-8
-    errors:
-    - {symerror: 8.01e-9, label: 'stat'}
-    - {symerror: 1.07e-8, label: 'sys'}
-  - value: 3.27e-8
-    errors:
-    - {symerror: 5.57e-9, label: 'stat'}
-    - {symerror: 5.87e-9, label: 'sys'}
-  - value: 2.99e-8
-    errors:
-    - {symerror: 5.70e-9, label: 'stat'}
-    - {symerror: 5.32e-9, label: 'sys'}
-  - value: 1.02e-8
-    errors:
-    - {symerror: 2.54e-9, label: 'stat'}
-    - {symerror: 1.79e-9, label: 'sys'}
-  - value: 1.41e-8
-    errors:
-    - {symerror: 3.39e-9, label: 'stat'}
-    - {symerror: 2.45e-9, label: 'sys'}
-  - value: 1.11e-8
-    errors:
-    - {symerror: 3.02e-9, label: 'stat'}
-    - {symerror: 1.88e-9, label: 'sys'}
-  - value: 4.13e-9
-    errors:
-    - {symerror: 1.24e-9, label: 'stat'}
-    - {symerror: 6.87e-10, label: 'sys'}
-  - value: 3.08e-9
-    errors:
-    - {symerror: 8.11e-105.02e-10, label: 'stat'}
-    - {symerror: 8.11e-105.02e-10, label: 'sys'}
-  - value: 2.50e-10
-    errors:
-    - {symerror: 8.33e-11, label: 'stat'}
-    - {symerror: 3.97e-11, label: 'sys'}
-- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
-  qualifiers:
-  - {name: '', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 10-20% Centrality, $1.2 < y < 2.2$'}
-  values:
-  - value: 3.59e-7
-    errors:
-    - {symerror: 6.98e-8, label: 'stat'}
-    - {symerror: 7.74e-8, label: 'sys'}
-  - value: 4.70e-7
-    errors:
-    - {symerror: 6.08e-8, label: 'stat'}
-    - {symerror: 1.00e-7, label: 'sys'}
-  - value: 3.66e-7
-    errors:
-    - {symerror: 3.51e-8, label: 'stat'}
-    - {symerror: 7.74e-8, label: 'sys'}
-  - value: 3.62e-7
-    errors:
-    - {symerror: 2.85e-8, label: 'stat'}
-    - {symerror: 7.55e-8, label: 'sys'}
-  - value: 2.98e-7
-    errors:
-    - {symerror: 2.14e-8, label: 'stat'}
-    - {symerror: 6.09e-8, label: 'sys'}
-  - value: 1.98e-7
-    errors:
-    - {symerror: 1.77e-8, label: 'stat'}
-    - {symerror: 3.95e-8, label: 'sys'}
-  - value: 1.80e-7
-    errors:
-    - {symerror: 1.42e-8, label: 'stat'}
-    - {symerror: 3.51e-8, label: 'sys'}
-  - value: 1.25e-7
-    errors:
-    - {symerror: 1.09e-8, label: 'stat'}
-    - {symerror: 2.38e-8, label: 'sys'}
-  - value: 9.89e-8
-    errors:
-    - {symerror: 8.93e-9, label: 'stat'}
-    - {symerror: 1.85e-8, label: 'sys'}
-  - value: 6.61e-8
-    errors:
-    - {symerror: 8.47e-9, label: 'stat'}
-    - {symerror: 1.22e-8, label: 'sys'}
-  - value: 4.52e-8
-    errors:
-    - {symerror: 5.02e-9, label: 'stat'}
-    - {symerror: 8.22e-9, label: 'sys'}
-  - value: 3.94e-8
-    errors:
-    - {symerror: 4.93e-9, label: 'stat'}
-    - {symerror: 7.09e-9, label: 'sys'}
-  - value: 2.20e-8
-    errors:
-    - {symerror: 3.20e-9, label: 'stat'}
-    - {symerror: 3.92e-9, label: 'sys'}
-  - value: 1.97e-8
-    errors:
-    - {symerror: 2.87e-9, label: 'stat'}
-    - {symerror: 3.47e-9, label: 'sys'}
-  - value: 1.71e-8
-    errors:
-    - {symerror: 2.57e-9, label: 'stat'}
-    - {symerror: 2.95e-9, label: 'sys'}
-  - value: 8.95e-9
-    errors:
-    - {symerror: 2.02e-9, label: 'stat'}
-    - {symerror: 1.52e-9, label: 'sys'}
-  - value: 5.09e-9
-    errors:
-    - {symerror: 8.47e-10, label: 'stat'}
-    - {symerror: 8.47e-10, label: 'sys'}
-  - value: 2.36e-9
-    errors:
-    - {symerror: 5.90e-10, label: 'stat'}
-    - {symerror: 3.84e-10, label: 'sys'}
-  - value: 3.49e-10
-    errors:
-    - {symerror: 6.98e-11, label: 'stat'}
-    - {symerror: 5.55e-11, label: 'sys'}
-- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
-  qualifiers:
-  - {name: '', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 0-20% Centrality, $1.2 < y < 2.2$'}
-  values:
-  - value: 3.95e-8
-    errors:
-    - {symerror: 5.44e-9, label: 'stat'}
-    - {symerror: 8.43e-9, label: 'sys'}
-  - value: 4.47e-8
-    errors:
-    - {symerror: 3.58e-9, label: 'stat'}
-    - {symerror: 9.47e-9, label: 'sys'}
-  - value: 3.22e-8
-    errors:
-    - {symerror: 2.15e-9, label: 'stat'}
-    - {symerror: 6.74e-9, label: 'sys'}
-  - value: 3.11e-8
-    errors:
-    - {symerror: 2.13e-9, label: 'stat'}
-    - {symerror: 6.41e-9, label: 'sys'}
-  - value: 3.14e-8
-    errors:
-    - {symerror: 1.37e-9, label: 'stat'}
-    - {symerror: 6.34e-9, label: 'sys'}
-  - value: 1.97e-8
-    errors:
-    - {symerror: 1.22e-9, label: 'stat'}
-    - {symerror: 3.89e-9, label: 'sys'}
-  - value: 1.86e-8
-    errors:
-    - {symerror: 1.16e-9, label: 'stat'}
-    - {symerror: 3.59e-9, label: 'sys'}
-  - value: 1.28e-8
-    errors:
-    - {symerror: 7.88e-10, label: 'stat'}
-    - {symerror: 2.41e-9, label: 'sys'}
-  - value: 1.04e-8
-    errors:
-    - {symerror: 8.63e-10, label: 'stat'}
-    - {symerror: 1.92e-9, label: 'sys'}
-  - value: 7.23e-9
-    errors:
-    - {symerror: 5.20e-10, label: 'stat'}
-    - {symerror: 1.31e-9, label: 'sys'}
-  - value: 5.61e-9
-    errors:
-    - {symerror: 4.42e-10, label: 'stat'}
-    - {symerror: 1.01e-9, label: 'sys'}
-  - value: 3.57e-9
-    errors:
-    - {symerror: 3.36e-10, label: 'stat'}
-    - {symerror: 6.34e-10, label: 'sys'}
-  - value: 2.77e-9
-    errors:
-    - {symerror: 2.83e-10, label: 'stat'}
-    - {symerror: 4.87e-10, label: 'sys'}
-  - value: 1.94e-9
-    errors:
-    - {symerror: 2.21e-10, label: 'stat'}
-    - {symerror: 3.37e-10, label: 'sys'}
-  - value: 1.65e-9
-    errors:
-    - {symerror: 1.83e-10, label: 'stat'}
-    - {symerror: 2.82e-10, label: 'sys'}
-  - value: 9.45e-10
-    errors:
-    - {symerror: 1.39e-10, label: 'stat'}
-    - {symerror: 1.58e-10, label: 'sys'}
-  - value: 5.54e-10
-    errors:
-    - {symerror: 5.75e-11, label: 'stat'}
-    - {symerror: 9.09e-11, label: 'sys'}
-  - value: 2.88e-10
-    errors:
-    - {symerror: 3.76e-11, label: 'stat'}
-    - {symerror: 4.61e-11, label: 'sys'}
-  - value: 3.30e-11
-    errors:
-    - {symerror: 4.12e-12, label: 'stat'}
-    - {symerror: 5.16e-12, label: 'sys'}
-- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
-  qualifiers:
-  - {name: '', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 20-40% Centrality, $1.2 < y < 2.2$'}
-  values:
-  - value: 3.20e-7
-    errors:
-    - {symerror: 4.65e-8, label: 'stat'}
-    - {symerror: 6.80e-8, label: 'sys'}
-  - value: 3.45e-7
-    errors:
-    - {symerror: 2.79e-8, label: 'stat'}
-    - {symerror: 7.27e-8, label: 'sys'}
-  - value: 2.42e-7
-    errors:
-    - {symerror: 2.02e-8, label: 'stat'}
-    - {symerror: 5.03e-8, label: 'sys'}
-  - value: 2.55e-7
-    errors:
-    - {symerror: 1.39e-8, label: 'stat'}
-    - {symerror: 5.24e-8, label: 'sys'}
-  - value: 2.53e-7
-    errors:
-    - {symerror: 1.53e-8, label: 'stat'}
-    - {symerror: 5.08e-8, label: 'sys'}
-  - value: 1.57e-7
-    errors:
-    - {symerror: 1.22e-8, label: 'stat'}
-    - {symerror: 3.08e-8, label: 'sys'}
-  - value: 1.39e-7
-    errors:
-    - {symerror: 1.04e-8, label: 'stat'}
-    - {symerror: 2.66e-8, label: 'sys'}
-  - value: 8.43e-8
-    errors:
-    - {symerror: 7.49e-9, label: 'stat'}
-    - {symerror: 1.58e-8, label: 'sys'}
-  - value: 7.00e-8
-    errors:
-    - {symerror: 5.91e-9, label: 'stat'}
-    - {symerror: 1.28e-8, label: 'sys'}
-  - value: 4.50e-8
-    errors:
-    - {symerror: 4.64e-9, label: 'stat'}
-    - {symerror: 8.11e-9, label: 'sys'}
-  - value: 3.76e-8
-    errors:
-    - {symerror: 4.38e-9, label: 'stat'}
-    - {symerror: 6.69e-9, label: 'sys'}
-  - value: 2.89e-8
-    errors:
-    - {symerror: 3.44e-9, label: 'stat'}
-    - {symerror: 5.08e-9, label: 'sys'}
-  - value: 2.20e-8
-    errors:
-    - {symerror: 2.45e-9, label: 'stat'}
-    - {symerror: 3.83e-9, label: 'sys'}
-  - value: 1.82e-8
-    errors:
-    - {symerror: 2.00e-9, label: 'stat'}
-    - {symerror: 3.13e-9, label: 'sys'}
-  - value: 1.04e-8
-    errors:
-    - {symerror: 1.63e-9, label: 'stat'}
-    - {symerror: 1.76e-9, label: 'sys'}
-  - value: 6.40e-9
-    errors:
-    - {symerror: 1.16e-9, label: 'stat'}
-    - {symerror: 1.06e-9, label: 'sys'}
-  - value: 5.47e-9
-    errors:
-    - {symerror: 6.07e-10, label: 'stat'}
-    - {symerror: 8.87e-10, label: 'sys'}
-  - value: 2.35e-9
-    errors:
-    - {symerror: 3.92e-10, label: 'stat'}
-    - {symerror: 3.73e-10, label: 'sys'}
-  - value: 2.92e-10
-    errors:
-    - {symerror: 4.09e-11, label: 'stat'}
-    - {symerror: 4.51e-11, label: 'sys'}
-- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
-  qualifiers:
-  - {name: '', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 40-60% Centrality, $1.2 < y < 2.2$'}
-  values:
-  - value: 2.79e-7
-    errors:
-    - {symerror: 6.54e-8, label: 'stat'}
-    - {symerror: 5.96e-8, label: 'sys'}
   - value: 2.70e-7
     errors:
-    - {symerror: 2.97e-8, label: 'stat'}
-    - {symerror: 5.71e-8, label: 'sys'}
-  - value: 1.73e-7
+    - {symerror: 5.39e-8, label: 'stat'}
+    - {symerror: 5.51e-8, label: 'sys'}
+  - value: 2.70e-7
     errors:
-    - {symerror: 2.04e-8, label: 'stat'}
-    - {symerror: 3.62e-8, label: 'sys'}
-  - value: 1.81e-7
+    - {symerror: 4.08e-8, label: 'stat'}
+    - {symerror: 5.43e-8, label: 'sys'}
+  - value: 2.63e-7
     errors:
-    - {symerror: 1.65e-8, label: 'stat'}
-    - {symerror: 3.73e-8, label: 'sys'}
-  - value: 1.92e-7
+    - {symerror: 2.74e-8, label: 'stat'}
+    - {symerror: 5.20e-8, label: 'sys'}
+  - value: 1.96e-7
     errors:
-    - {symerror: 1.24e-8, label: 'stat'}
-    - {symerror: 3.89e-8, label: 'sys'}
-  - value: 1.22e-7
+    - {symerror: 2.02e-8, label: 'stat'}
+    - {symerror: 3.82e-8, label: 'sys'}
+  - value: 1.79e-7
     errors:
-    - {symerror: 1.19e-8, label: 'stat'}
-    - {symerror: 2.40e-8, label: 'sys'}
-  - value: 1.09e-7
+    - {symerror: 1.72e-8, label: 'stat'}
+    - {symerror: 3.42e-8, label: 'sys'}
+  - value: 1.76e-7
     errors:
-    - {symerror: 1.07e-8, label: 'stat'}
-    - {symerror: 2.09e-8, label: 'sys'}
-  - value: 7.54e-8
+    - {symerror: 1.52e-8, label: 'stat'}
+    - {symerror: 3.29e-8, label: 'sys'}
+  - value: 1.26e-7
     errors:
-    - {symerror: 6.74e-9, label: 'stat'}
-    - {symerror: 1.42e-8, label: 'sys'}
-  - value: 5.74e-8
+    - {symerror: 1.12e-8, label: 'stat'}
+    - {symerror: 2.32e-8, label: 'sys'}
+  - value: 1.03e-7
     errors:
-    - {symerror: 5.55e-9, label: 'stat'}
-    - {symerror: 1.06e-8, label: 'sys'}
-  - value: 4.06e-8
+    - {symerror: 9.64e-9, label: 'stat'}
+    - {symerror: 1.86e-8, label: 'sys'}
+  - value: 6.20e-8
     errors:
-    - {symerror: 4.26e-9, label: 'stat'}
-    - {symerror: 7.37e-9, label: 'sys'}
-  - value: 2.88e-8
+    - {symerror: 6.56e-9, label: 'stat'}
+    - {symerror: 1.10e-8, label: 'sys'}
+  - value: 4.26e-8
     errors:
-    - {symerror: 2.91e-9, label: 'stat'}
-    - {symerror: 5.16e-9, label: 'sys'}
-  - value: 2.10e-8
+    - {symerror: 6.24e-9, label: 'stat'}
+    - {symerror: 7.46e-9, label: 'sys'}
+  - value: 3.64e-8
     errors:
-    - {symerror: 2.85e-9, label: 'stat'}
-    - {symerror: 3.72e-9, label: 'sys'}
-  - value: 1.12e-8
+    - {symerror: 4.55e-9, label: 'stat'}
+    - {symerror: 6.27e-9, label: 'sys'}
+  - value: 2.68e-8
     errors:
-    - {symerror: 1.84e-9, label: 'stat'}
-    - {symerror: 2.10e-9, label: 'sys'}
-  - value: 1.09e-8
+    - {symerror: 3.60e-9, label: 'stat'}
+    - {symerror: 4.53e-9, label: 'sys'}
+  - value: 2.11e-8
     errors:
-    - {symerror: 1.64e-9, label: 'stat'}
-    - {symerror: 1.89e-9, label: 'sys'}
-  - value: 5.87e-9
+    - {symerror: 3.17e-9, label: 'stat'}
+    - {symerror: 3.51e-9, label: 'sys'}
+  - value: 1.62e-8
     errors:
-    - {symerror: 1.10e-9, label: 'stat'}
-    - {symerror: 1.00e-9, label: 'sys'}
-  - value: 6.06e-9
+    - {symerror: 2.49e-9, label: 'stat'}
+    - {symerror: 2.63e-9, label: 'sys'}
+  - value: 1.13e-8
     errors:
-    - {symerror: 1.15e-9, label: 'stat'}
-    - {symerror: 1.01e-9, label: 'sys'}
-  - value: 2.85e-9
+    - {symerror: 1.93e-9, label: 'stat'}
+    - {symerror: 1.79e-9, label: 'sys'}
+  - value: 6.87e-9
     errors:
-    - {symerror: 4.75e-10, label: 'stat'}
-    - {symerror: 4.68e-10, label: 'sys'}
-  - value: 1.20e-9
+    - {symerror: 1.47e-9, label: 'stat'}
+    - {symerror: 1.06e-9, label: 'sys'}
+  - value: 4.08e-9
     errors:
-    - {symerror: 2.72e-10, label: 'stat'}
-    - {symerror: 1.92e-10, label: 'sys'}
-  - value: 1.57e-10
+    - {symerror: 7.14e-10, label: 'stat'}
+    - {symerror: 6.18e-10, label: 'sys'}
+  - value: 1.98e-9
     errors:
-    - {symerror: 4.22e-11, label: 'stat'}
-    - {symerror: 2.45e-11, label: 'sys'}
-- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 11.8%)'}
+    - {symerror: 4.13e-10, label: 'stat'}
+    - {symerror: 2.93e-10, label: 'sys'}
+  - value: 3.80e-10
+    errors:
+    - {symerror: 6.34e-11, label: 'stat'}
+    - {symerror: 5.49e-11, label: 'sys'}
+- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
   qualifiers:
-  - {name: '', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 60-84% Centrality, $1.2 < y < 2.2$'}
+  - {name: '$p_{T}[GeV/c]$', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 5--10% Centrality, $1.2 < y < 2.2$'}
   values:
+  - value: 2.92e-7
+    errors:
+    - {symerror: 5.65e-8, label: 'stat'}
+    - {symerror: 5.96e-8, label: 'sys'}
+  - value: 3.12e-7
+    errors:
+    - {symerror: 3.35e-8, label: 'stat'}
+    - {symerror: 6.27e-8, label: 'sys'}
+  - value: 2.37e-7
+    errors:
+    - {symerror: 2.75e-8, label: 'stat'}
+    - {symerror: 4.69e-8, label: 'sys'}
+  - value: 2.30e-7
+    errors:
+    - {symerror: 2.35e-8, label: 'stat'}
+    - {symerror: 4.48e-8, label: 'sys'}
+  - value: 2.03e-7
+    errors:
+    - {symerror: 2.11e-8, label: 'stat'}
+    - {symerror: 3.88e-8, label: 'sys'}
   - value: 1.53e-7
     errors:
-    - {symerror: 3.58e-8, label: 'stat'}
-    - {symerror: 3.26e-8, label: 'sys'}
-  - value: 1.70e-7
+    - {symerror: 1.54e-8, label: 'stat'}
+    - {symerror: 2.87e-8, label: 'sys'}
+  - value: 1.19e-7
     errors:
-    - {symerror: 2.34e-8, label: 'stat'}
-    - {symerror: 3.60e-8, label: 'sys'}
-  - value: 1.12e-7
+    - {symerror: 1.12e-8, label: 'stat'}
+    - {symerror: 2.19e-8, label: 'sys'}
+  - value: 8.62e-8
     errors:
-    - {symerror: 1.50e-8, label: 'stat'}
-    - {symerror: 2.50e-8, label: 'sys'}
+    - {symerror: 9.58e-9, label: 'stat'}
+    - {symerror: 1.56e-8, label: 'sys'}
+  - value: 8.06e-8
+    errors:
+    - {symerror: 7.62e-9, label: 'stat'}
+    - {symerror: 1.43e-8, label: 'sys'}
+  - value: 4.57e-8
+    errors:
+    - {symerror: 5.51e-9, label: 'stat'}
+    - {symerror: 8.00e-9, label: 'sys'}
+  - value: 3.27e-8
+    errors:
+    - {symerror: 4.32e-9, label: 'stat'}
+    - {symerror: 5.63e-9, label: 'sys'}
+  - value: 2.48e-8
+    errors:
+    - {symerror: 4.21e-9, label: 'stat'}
+    - {symerror: 4.20e-9, label: 'sys'}
+  - value: 1.96e-8
+    errors:
+    - {symerror: 3.33e-9, label: 'stat'}
+    - {symerror: 3.26e-9, label: 'sys'}
+  - value: 2.19e-8
+    errors:
+    - {symerror: 2.94e-9, label: 'stat'}
+    - {symerror: 3.56e-9, label: 'sys'}
+  - value: 8.99e-9
+    errors:
+    - {symerror: 1.74e-9, label: 'stat'}
+    - {symerror: 1.43e-9, label: 'sys'}
+  - value: 6.45e-9
+    errors:
+    - {symerror: 1.55e-9, label: 'stat'}
+    - {symerror: 1.00e-9, label: 'sys'}
+  - value: 4.41e-9
+    errors:
+    - {symerror: 7.54e-10, label: 'stat'}
+    - {symerror: 6.68e-10, label: 'sys'}
+  - value: 2.45e-9
+    errors:
+    - {symerror: 5.25e-10, label: 'stat'}
+    - {symerror: 3.62e-10, label: 'sys'}
+  - value: 3.61e-10
+    errors:
+    - {symerror: 6.77e-11, label: 'stat'}
+    - {symerror: 5.21e-11, label: 'sys'}
+- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
+  qualifiers:
+  - {name: '$p_{T}[GeV/c]$', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 10--20% Centrality, $1.2 < y < 2.2$'}
+  values:
+  - value: 3.60e-7
+    errors:
+    - {symerror: 4.63e-8, label: 'stat'}
+    - {symerror: 7.36e-8, label: 'sys'}
+  - value: 2.66e-7
+    errors:
+    - {symerror: 2.48e-8, label: 'stat'}
+    - {symerror: 5.35e-8, label: 'sys'}
+  - value: 2.45e-7
+    errors:
+    - {symerror: 1.97e-8, label: 'stat'}
+    - {symerror: 4.84e-8, label: 'sys'}
+  - value: 2.40e-7
+    errors:
+    - {symerror: 1.67e-8, label: 'stat'}
+    - {symerror: 4.67e-8, label: 'sys'}
+  - value: 2.04e-7
+    errors:
+    - {symerror: 1.32e-8, label: 'stat'}
+    - {symerror: 3.91e-8, label: 'sys'}
+  - value: 1.36e-7
+    errors:
+    - {symerror: 1.08e-8, label: 'stat'}
+    - {symerror: 2.55e-8, label: 'sys'}
   - value: 1.14e-7
     errors:
-    - {symerror: 1.00e-8, label: 'stat'}
-    - {symerror: 2.34e-8, label: 'sys'}
-  - value: 7.51e-8
+    - {symerror: 8.71e-9, label: 'stat'}
+    - {symerror: 2.10e-8, label: 'sys'}
+  - value: 8.59e-8
     errors:
-    - {symerror: 7.28e-9, label: 'stat'}
-    - {symerror: 1.51e-8, label: 'sys'}
-  - value: 6.02e-8
+    - {symerror: 7.09e-9, label: 'stat'}
+    - {symerror: 1.55e-8, label: 'sys'}
+  - value: 6.60e-8
+    errors:
+    - {symerror: 5.17e-9, label: 'stat'}
+    - {symerror: 1.17e-8, label: 'sys'}
+  - value: 4.77e-8
+    errors:
+    - {symerror: 4.51e-9, label: 'stat'}
+    - {symerror: 8.34e-9, label: 'sys'}
+  - value: 3.88e-8
+    errors:
+    - {symerror: 3.71e-9, label: 'stat'}
+    - {symerror: 6.69e-9, label: 'sys'}
+  - value: 3.11e-8
+    errors:
+    - {symerror: 2.83e-9, label: 'stat'}
+    - {symerror: 5.27e-9, label: 'sys'}
+  - value: 1.96e-8
+    errors:
+    - {symerror: 2.11e-9, label: 'stat'}
+    - {symerror: 3.25e-9, label: 'sys'}
+  - value: 1.48e-8
+    errors:
+    - {symerror: 1.70e-9, label: 'stat'}
+    - {symerror: 2.40e-9, label: 'sys'}
+  - value: 9.07e-9
+    errors:
+    - {symerror: 1.21e-9, label: 'stat'}
+    - {symerror: 1.44e-9, label: 'sys'}
+  - value: 8.07e-9
+    errors:
+    - {symerror: 1.08e-9, label: 'stat'}
+    - {symerror: 1.25e-9, label: 'sys'}
+  - value: 3.42e-9
+    errors:
+    - {symerror: 4.49e-10, label: 'stat'}
+    - {symerror: 5.18e-10, label: 'sys'}
+  - value: 2.50e-9
+    errors:
+    - {symerror: 3.63e-10, label: 'stat'}
+    - {symerror: 3.69e-10, label: 'sys'}
+- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
+  qualifiers:
+  - {name: '$p_{T}[GeV/c]$', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 0--20% Centrality, $1.2 < y < 2.2$'}
+  values:
+  - value: 3.53e-7
+    errors:
+    - {symerror: 3.81e-8, label: 'stat'}
+    - {symerror: 7.19e-8, label: 'sys'}
+  - value: 3.04e-7
+    errors:
+    - {symerror: 2.29e-8, label: 'stat'}
+    - {symerror: 6.10e-8, label: 'sys'}
+  - value: 2.52e-7
+    errors:
+    - {symerror: 1.69e-8, label: 'stat'}
+    - {symerror: 4.97e-8, label: 'sys'}
+  - value: 2.30e-7
+    errors:
+    - {symerror: 1.40e-8, label: 'stat'}
+    - {symerror: 4.47e-8, label: 'sys'}
+  - value: 2.06e-7
+    errors:
+    - {symerror: 9.74e-9, label: 'stat'}
+    - {symerror: 3.93e-8, label: 'sys'}
+  - value: 1.53e-7
+    errors:
+    - {symerror: 8.24e-9, label: 'stat'}
+    - {symerror: 2.87e-8, label: 'sys'}
+  - value: 1.20e-7
+    errors:
+    - {symerror: 6.50e-9, label: 'stat'}
+    - {symerror: 2.21e-8, label: 'sys'}
+  - value: 9.36e-8
+    errors:
+    - {symerror: 5.37e-9, label: 'stat'}
+    - {symerror: 1.69e-8, label: 'sys'}
+  - value: 6.90e-8
+    errors:
+    - {symerror: 4.00e-9, label: 'stat'}
+    - {symerror: 1.22e-8, label: 'sys'}
+  - value: 4.67e-8
+    errors:
+    - {symerror: 3.20e-9, label: 'stat'}
+    - {symerror: 8.17e-9, label: 'sys'}
+  - value: 3.65e-8
+    errors:
+    - {symerror: 2.56e-9, label: 'stat'}
+    - {symerror: 6.27e-9, label: 'sys'}
+  - value: 2.96e-8
+    errors:
+    - {symerror: 2.25e-9, label: 'stat'}
+    - {symerror: 4.99e-9, label: 'sys'}
+  - value: 2.08e-8
+    errors:
+    - {symerror: 1.71e-9, label: 'stat'}
+    - {symerror: 3.44e-9, label: 'sys'}
+  - value: 1.76e-8
+    errors:
+    - {symerror: 1.35e-9, label: 'stat'}
+    - {symerror: 2.84e-9, label: 'sys'}
+  - value: 9.97e-9
+    errors:
+    - {symerror: 9.75e-10, label: 'stat'}
+    - {symerror: 1.58e-9, label: 'sys'}
+  - value: 7.85e-9
+    errors:
+    - {symerror: 8.05e-10, label: 'stat'}
+    - {symerror: 1.21e-9, label: 'sys'}
+  - value: 4.04e-9
+    errors:
+    - {symerror: 3.96e-10, label: 'stat'}
+    - {symerror: 6.08e-10, label: 'sys'}
+  - value: 2.79e-9
+    errors:
+    - {symerror: 2.79e-10, label: 'stat'}
+    - {symerror: 4.10e-10, label: 'sys'}
+  - value: 4.54e-10
+    errors:
+    - {symerror: 4.07e-11, label: 'stat'}
+    - {symerror: 6.52e-11, label: 'sys'}
+- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
+  qualifiers:
+  - {name: '$p_{T}[GeV/c]$', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 20--40% Centrality, $1.2 < y < 2.2$'}
+  values:
+  - value: 2.78e-7
+    errors:
+    - {symerror: 3.33e-8, label: 'stat'}
+    - {symerror: 5.66e-8, label: 'sys'}
+  - value: 2.84e-7
+    errors:
+    - {symerror: 2.22e-8, label: 'stat'}
+    - {symerror: 5.69e-8, label: 'sys'}
+  - value: 2.26e-7
+    errors:
+    - {symerror: 1.44e-8, label: 'stat'}
+    - {symerror: 4.45e-8, label: 'sys'}
+  - value: 2.15e-7
+    errors:
+    - {symerror: 1.58e-8, label: 'stat'}
+    - {symerror: 4.17e-8, label: 'sys'}
+  - value: 1.92e-7
+    errors:
+    - {symerror: 9.68e-9, label: 'stat'}
+    - {symerror: 3.67e-8, label: 'sys'}
+  - value: 1.47e-7
+    errors:
+    - {symerror: 7.68e-9, label: 'stat'}
+    - {symerror: 2.76e-8, label: 'sys'}
+  - value: 1.21e-7
     errors:
     - {symerror: 6.48e-9, label: 'stat'}
-    - {symerror: 1.18e-8, label: 'sys'}
-  - value: 5.61e-8
+    - {symerror: 2.23e-8, label: 'sys'}
+  - value: 8.82e-8
     errors:
-    - {symerror: 5.53e-9, label: 'stat'}
-    - {symerror: 1.08e-8, label: 'sys'}
-  - value: 3.75e-8
+    - {symerror: 5.14e-9, label: 'stat'}
+    - {symerror: 1.59e-8, label: 'sys'}
+  - value: 6.46e-8
     errors:
-    - {symerror: 3.78e-9, label: 'stat'}
-    - {symerror: 7.03e-9, label: 'sys'}
-  - value: 2.91e-8
+    - {symerror: 3.92e-9, label: 'stat'}
+    - {symerror: 1.15e-8, label: 'sys'}
+  - value: 4.94e-8
     errors:
-    - {symerror: 3.64e-9, label: 'stat'}
-    - {symerror: 5.35e-9, label: 'sys'}
-  - value: 2.21e-8
+    - {symerror: 3.11e-9, label: 'stat'}
+    - {symerror: 8.61e-9, label: 'sys'}
+  - value: 3.46e-8
     errors:
-    - {symerror: 2.70e-9, label: 'stat'}
-    - {symerror: 4.00e-9, label: 'sys'}
-  - value: 1.52e-8
+    - {symerror: 2.31e-9, label: 'stat'}
+    - {symerror: 5.93e-9, label: 'sys'}
+  - value: 2.54e-8
     errors:
-    - {symerror: 2.17e-9, label: 'stat'}
-    - {symerror: 2.72e-9, label: 'sys'}
-  - value: 1.30e-8
+    - {symerror: 2.04e-9, label: 'stat'}
+    - {symerror: 4.28e-9, label: 'sys'}
+  - value: 1.88e-8
     errors:
-    - {symerror: 1.73e-9, label: 'stat'}
-    - {symerror: 2.29e-9, label: 'sys'}
-  - value: 8.57e-9
+    - {symerror: 1.48e-9, label: 'stat'}
+    - {symerror: 3.11e-9, label: 'sys'}
+  - value: 1.27e-8
     errors:
-    - {symerror: 1.36e-9, label: 'stat'}
-    - {symerror: 1.49e-9, label: 'sys'}
-  - value: 4.90e-9
+    - {symerror: 1.22e-9, label: 'stat'}
+    - {symerror: 2.05e-9, label: 'sys'}
+  - value: 9.50e-9
     errors:
-    - {symerror: 1.05e-9, label: 'stat'}
-    - {symerror: 8.45e-10, label: 'sys'}
-  - value: 4.56e-9
+    - {symerror: 1.00e-9, label: 'stat'}
+    - {symerror: 1.50e-9, label: 'sys'}
+  - value: 6.68e-9
     errors:
-    - {symerror: 9.44e-10, label: 'stat'}
-    - {symerror: 7.75e-10, label: 'sys'}
-  - value: 3.11e-9
+    - {symerror: 7.42e-10, label: 'stat'}
+    - {symerror: 1.03e-9, label: 'sys'}
+  - value: 4.15e-9
     errors:
-    - {symerror: 7.08e-10, label: 'stat'}
+    - {symerror: 4.33e-10, label: 'stat'}
+    - {symerror: 6.25e-10, label: 'sys'}
+  - value: 1.70e-9
+    errors:
+    - {symerror: 2.51e-10, label: 'stat'}
+    - {symerror: 2.51e-10, label: 'sys'}
+  - value: 3.79e-10
+    errors:
+    - {symerror: 3.76e-11, label: 'stat'}
+    - {symerror: 5.43e-11, label: 'sys'}
+- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 10.2%)'}
+  qualifiers:
+  - {name: '$p_{T}[GeV/c]$', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 40--60% Centrality, $1.2 < y < 2.2$'}
+  values:
+  - value: 2.78e-7
+    errors:
+    - {symerror: 2.90e-8, label: 'stat'}
+    - {symerror: 5.67e-8, label: 'sys'}
+  - value: 2.58e-7
+    errors:
+    - {symerror: 1.93e-8, label: 'stat'}
+    - {symerror: 5.18e-8, label: 'sys'}
+  - value: 1.81e-7
+    errors:
+    - {symerror: 1.46e-8, label: 'stat'}
+    - {symerror: 3.57e-8, label: 'sys'}
+  - value: 1.88e-7
+    errors:
+    - {symerror: 1.25e-8, label: 'stat'}
+    - {symerror: 3.66e-8, label: 'sys'}
+  - value: 1.49e-7
+    errors:
+    - {symerror: 8.39e-9, label: 'stat'}
+    - {symerror: 2.84e-8, label: 'sys'}
+  - value: 1.22e-7
+    errors:
+    - {symerror: 7.48e-9, label: 'stat'}
+    - {symerror: 2.29e-8, label: 'sys'}
+  - value: 1.04e-7
+    errors:
+    - {symerror: 6.04e-9, label: 'stat'}
+    - {symerror: 1.92e-8, label: 'sys'}
+  - value: 5.73e-8
+    errors:
+    - {symerror: 4.51e-9, label: 'stat'}
+    - {symerror: 1.03e-8, label: 'sys'}
+  - value: 4.89e-8
+    errors:
+    - {symerror: 3.15e-9, label: 'stat'}
+    - {symerror: 8.68e-9, label: 'sys'}
+  - value: 3.39e-8
+    errors:
+    - {symerror: 2.74e-9, label: 'stat'}
+    - {symerror: 5.91e-9, label: 'sys'}
+  - value: 2.51e-8
+    errors:
+    - {symerror: 1.98e-9, label: 'stat'}
+    - {symerror: 4.32e-9, label: 'sys'}
+  - value: 2.06e-8
+    errors:
+    - {symerror: 1.74e-9, label: 'stat'}
+    - {symerror: 3.48e-9, label: 'sys'}
+  - value: 1.54e-8
+    errors:
+    - {symerror: 1.43e-9, label: 'stat'}
+    - {symerror: 2.55e-9, label: 'sys'}
+  - value: 9.85e-9
+    errors:
+    - {symerror: 1.07e-9, label: 'stat'}
+    - {symerror: 1.60e-9, label: 'sys'}
+  - value: 9.04e-9
+    errors:
+    - {symerror: 9.56e-10, label: 'stat'}
+    - {symerror: 1.43e-9, label: 'sys'}
+  - value: 4.82e-9
+    errors:
+    - {symerror: 6.22e-10, label: 'stat'}
+    - {symerror: 7.45e-10, label: 'sys'}
+  - value: 2.81e-9
+    errors:
+    - {symerror: 3.27e-10, label: 'stat'}
+    - {symerror: 4.24e-10, label: 'sys'}
+  - value: 1.90e-9
+    errors:
+    - {symerror: 2.67e-10, label: 'stat'}
+    - {symerror: 2.79e-10, label: 'sys'}
+  - value: 2.68e-10
+    errors:
+    - {symerror: 3.47e-11, label: 'stat'}
+    - {symerror: 3.85e-11, label: 'sys'}
+- header: {name: '$\frac{1}{2\pi p_{T} \Delta p_{T} \Delta y} \frac{c_\mathrm{BBC}}{\varepsilon_\mathrm{Ae} \varepsilon_\mathrm{trig}} \frac{N_{J/\psi}}{N_\mathrm{evt}}$  (global err. 11.8%)'}
+  qualifiers:
+  - {name: '$p_{T}[GeV/c]$', value: '$\frac{B_{ll}}{2\pi p_{T}} \frac{d^{2}N}{dydp_{T}}$,  p+Au$\sqrt{s_{NN}}$=200GeV, 60--84% Centrality, $1.2 < y < 2.2$'}
+  values:
+  - value: 1.89e-7
+    errors:
+    - {symerror: 2.33e-8, label: 'stat'}
+    - {symerror: 3.84e-8, label: 'sys'}
+  - value: 1.62e-7
+    errors:
+    - {symerror: 1.40e-8, label: 'stat'}
+    - {symerror: 3.25e-8, label: 'sys'}
+  - value: 1.48e-7
+    errors:
+    - {symerror: 1.03e-8, label: 'stat'}
+    - {symerror: 2.91e-8, label: 'sys'}
+  - value: 1.33e-7
+    errors:
+    - {symerror: 9.08e-9, label: 'stat'}
+    - {symerror: 2.58e-8, label: 'sys'}
+  - value: 8.80e-8
+    errors:
+    - {symerror: 6.26e-9, label: 'stat'}
+    - {symerror: 1.68e-8, label: 'sys'}
+  - value: 7.41e-8
+    errors:
+    - {symerror: 5.38e-9, label: 'stat'}
+    - {symerror: 1.39e-8, label: 'sys'}
+  - value: 5.50e-8
+    errors:
+    - {symerror: 4.31e-9, label: 'stat'}
+    - {symerror: 1.01e-8, label: 'sys'}
+  - value: 4.07e-8
+    errors:
+    - {symerror: 2.97e-9, label: 'stat'}
+    - {symerror: 7.33e-9, label: 'sys'}
+  - value: 2.98e-8
+    errors:
+    - {symerror: 2.41e-9, label: 'stat'}
+    - {symerror: 5.27e-9, label: 'sys'}
+  - value: 2.39e-8
+    errors:
+    - {symerror: 2.09e-9, label: 'stat'}
+    - {symerror: 4.16e-9, label: 'sys'}
+  - value: 1.66e-8
+    errors:
+    - {symerror: 1.60e-9, label: 'stat'}
+    - {symerror: 2.84e-9, label: 'sys'}
+  - value: 1.16e-8
+    errors:
+    - {symerror: 1.21e-9, label: 'stat'}
+    - {symerror: 1.94e-9, label: 'sys'}
+  - value: 9.50e-9
+    errors:
+    - {symerror: 1.07e-9, label: 'stat'}
+    - {symerror: 1.57e-9, label: 'sys'}
+  - value: 8.50e-9
+    errors:
+    - {symerror: 9.45e-10, label: 'stat'}
+    - {symerror: 1.37e-9, label: 'sys'}
+  - value: 3.30e-9
+    errors:
+    - {symerror: 4.91e-10, label: 'stat'}
     - {symerror: 5.19e-10, label: 'sys'}
+  - value: 2.32e-9
+    errors:
+    - {symerror: 4.39e-10, label: 'stat'}
+    - {symerror: 3.57e-10, label: 'sys'}
   - value: 1.66e-9
     errors:
-    - {symerror: 3.57e-10, label: 'stat'}
-    - {symerror: 2.71e-10, label: 'sys'}
-  - value: 9.63e-10
+    - {symerror: 2.37e-10, label: 'stat'}
+    - {symerror: 2.49e-10, label: 'sys'}
+  - value: 9.48e-10
     errors:
-    - {symerror: 1.93e-10, label: 'stat'}
-    - {symerror: 1.53e-10, label: 'sys'}
-  - value: 1.01e-10
+    - {symerror: 1.72e-10, label: 'stat'}
+    - {symerror: 1.39e-10, label: 'sys'}
+  - value: 1.61e-10
     errors:
-    - {symerror: 2.25e-11, label: 'stat'}
-    - {symerror: 1.57e-11, label: 'sys'}
+    - {symerror: 2.54e-11, label: 'stat'}
+    - {symerror: 2.30e-11, label: 'sys'}


### PR DESCRIPTION
Table 16:  The column for RpAu 0-20% South had values for RpAu 20-40% South
Table 18:  The columns for RpAl North and South had values for RHeAu
Table 21:  The columns for RpAl North and South had values for RHeAu 
Table 22:  The columns for RpAu North and South had values for RHeAu 
Table 27:  The column for MB RpAu had values for MB RHeAu and the column for MB RHeAu had values for RHeAu 0-20%
Table 33:  All columns for RpAu North had values for RpAu South